### PR TITLE
279 handle missformated url in accomodation link

### DIFF
--- a/move_together_app/lib/Accommodation/accommodation_screen.dart
+++ b/move_together_app/lib/Accommodation/accommodation_screen.dart
@@ -114,8 +114,8 @@ class AccommodationScreen extends StatelessWidget {
                     ],
                   ),
                   (accommodation.bookingUrl != null &&
-                          accommodation.bookingUrl!.isNotEmpty && Uri.parse(
-                              accommodation.bookingUrl!).isAbsolute)
+                          accommodation.bookingUrl!.isNotEmpty &&
+                          Uri.parse(accommodation.bookingUrl!).isAbsolute)
                       ? Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [

--- a/move_together_app/lib/Accommodation/accommodation_screen.dart
+++ b/move_together_app/lib/Accommodation/accommodation_screen.dart
@@ -114,7 +114,8 @@ class AccommodationScreen extends StatelessWidget {
                     ],
                   ),
                   (accommodation.bookingUrl != null &&
-                          accommodation.bookingUrl!.isNotEmpty)
+                          accommodation.bookingUrl!.isNotEmpty && Uri.parse(
+                              accommodation.bookingUrl!).isAbsolute)
                       ? Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [


### PR DESCRIPTION
si url valide : on affiche le bouton qui ouvre direct, sinon non